### PR TITLE
chore(setup): set up dev environment (Node 14, wds pin, AGENTS.md)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,52 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This repo (`vitis-lowcode-engine`) is a Lerna + Yarn-workspaces monorepo that builds a
+low-code visual editor engine. It is the companion source for a book and ships only the
+engine resource bundles (there is **no application host page / demo and no backend**).
+
+### Toolchain (already provisioned in the VM)
+- **Node 14** is required (`engines.node` = `>=14.18.0 <16`). Node `14.21.3` is installed via
+  nvm and prepended to `PATH` in `~/.bashrc` (the VM also has a Node 22 at `/exec-daemon/node`
+  that must NOT be used for this repo). `node -v` should report `v14.x`.
+- Package manager is **Yarn 1** (classic), installed under the Node 14 nvm. There are no
+  committed lockfiles (`yarn.lock`/`package-lock.json` are git-ignored and deleted by setup).
+
+### Install / build / run
+- Install deps: `yarn install --ignore-engines` (the `--ignore-engines` is required because a
+  transitive dep, `node-releases`, declares `node>=18`). This is the startup update script.
+- Build all packages (npm + UMD, in dependency order): `npm run build` (see `scripts/build.sh`).
+- Run the dev server (the "ignitor"): `npm run start` → webpack-dev-server on **port 5555**.
+  It serves the compiled engine resources at `/js/engine-core.js`, `/css/engine-core.css`,
+  `/engine-core.html`, `/simulator-renderer.html`. Static files placed in
+  `packages/ignitor/public/` are also served at `/`.
+- There are **no lint or test scripts** in this repo.
+
+### Non-obvious gotchas
+- **webpack-dev-server is pinned to `3.11.3`** via root `package.json` `resolutions`. Without
+  this pin, a fresh install resolves wds v4, but the (transitive) `@builder/user-config` default
+  dev-server config uses v3-only options (`before`, `disableHostCheck`, `transportMode`, `quiet`,
+  …), so `npm run start` crashes with a `ValidationError: options has an unknown property 'before'`.
+  Keep this resolution. (If this change is not merged, re-add it before running the dev server.)
+- The dev server restarts automatically when `packages/ignitor/build.json` changes (a chokidar
+  watcher in `build-scripts`), so don't be surprised by a recompile after editing it.
+- **The engine is a UMD library with no host page.** To actually view/run the editor you must
+  create a host HTML that loads React/ReactDOM 17 UMD, the engine bundle, calls
+  `VitisLowCodeEngine.material.load([...])` and `VitisLowCodeEngine.init(container, { pageSchema })`.
+  Real components are published on npm and fetched from the component market (unpkg), e.g.
+  `vitis-lowcode-row`, `vitis-lowcode-column`, `vitis-lowcode-input`.
+- **Externals bug in the UMD bundles:** `build.umd.json` (and the published bundles) declare
+  `externals: { react: "window.React" }`, which webpack compiles to a `self["window.React"]`
+  global lookup instead of `window.React`. So a host page must set
+  `window["window.React"] = React; window["window.ReactDOM"] = ReactDOM;` before loading the
+  engine UMD. The **dev** bundle (`/js/engine-core.js`) additionally exposes the
+  webpack-dev-server client as the `VitisLowCodeEngine` global (because the inline-client entry
+  is the last entry under `output.library`); use the **built UMD** (`packages/engine/dist/js/engine-core.js`)
+  in a host page instead.
+- **Canvas live preview is currently broken** end-to-end: the design canvas iframe loads the
+  *published* `vitis-lowcode-simulator-renderer` UMD from unpkg (hardcoded in
+  `packages/engine/src/utils.ts` `getBaseAssets`), which has the same `window.React` externals
+  bug, so React is `undefined` inside the iframe and rendering throws (`createContext of undefined`).
+  Fixing it requires editing engine source, so the schema/component-market/setter panes work but
+  the visual canvas does not without code changes.

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "node": ">=14.18.0 <16"
   },
   "resolutions": {
-    "@builder/babel-preset-ice": "1.0.1"
+    "@builder/babel-preset-ice": "1.0.1",
+    "webpack-dev-server": "3.11.3"
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for `vitis-lowcode-engine` (Lerna + Yarn-workspaces monorepo, low-code visual editor). No application logic was changed.

- **Pin `webpack-dev-server` to `3.11.3`** via root `package.json` `resolutions`. With no committed lockfile, a fresh install otherwise resolves wds v4, which rejects the v3-only dev-server options injected by the transitive `@builder/user-config` (`before`, `disableHostCheck`, `transportMode`, `quiet`, …), crashing `npm run start` with `ValidationError: ... unknown property 'before'`.
- **Add `AGENTS.md`** documenting the Node 14 toolchain, install/build/run commands, and non-obvious gotchas (UMD `window.React` externals bug, dev bundle library quirk, canvas-preview limitation).

## Environment

- Node `14.21.3` via nvm (`engines.node` = `>=14.18.0 <16`); PATH set in `~/.bashrc` (a Node 22 at `/exec-daemon/node` must not be used).
- Yarn 1 (classic). Update script: `yarn install --ignore-engines` (transitive `node-releases` requires `node>=18`).

## Verification

- ✅ `yarn install --ignore-engines`
- ✅ `npm run build` (all 8 packages + UMD bundles compiled)
- ✅ `npm run start` (ignitor dev server on port 5555)
- ✅ Editor loaded in browser: component market (Row/Column/Input fetched from the live market), live page schema, and an interactive edit to a network interceptor persisted into the engine schema.

### Walkthrough
[lowcode_engine_editor_demo.mp4](https://cursor.com/agents/bc-362bc9ef-bb1c-4f43-ace7-e6916a873ae0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flowcode_engine_editor_demo.mp4)

[Engine ready](https://cursor.com/agents/bc-362bc9ef-bb1c-4f43-ace7-e6916a873ae0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2F01_engine_ready.webp)
[Component market](https://cursor.com/agents/bc-362bc9ef-bb1c-4f43-ace7-e6916a873ae0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2F02_component_market.webp)
[Live schema](https://cursor.com/agents/bc-362bc9ef-bb1c-4f43-ace7-e6916a873ae0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2F03_live_schema_interceptors.webp)
[Edit interceptor](https://cursor.com/agents/bc-362bc9ef-bb1c-4f43-ace7-e6916a873ae0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2F04_edit_interceptor.webp)
[Edit persisted into schema](https://cursor.com/agents/bc-362bc9ef-bb1c-4f43-ace7-e6916a873ae0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2F05_schema_persisted_edit.webp)

### Known limitation
The engine ships no host page, and the published `vitis-lowcode-simulator-renderer` UMD has a `window.React` externals bug, so the design **canvas iframe** preview cannot render without modifying engine source (out of scope for environment setup). The schema / component-market / setter panes are fully functional.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-362bc9ef-bb1c-4f43-ace7-e6916a873ae0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-362bc9ef-bb1c-4f43-ace7-e6916a873ae0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

